### PR TITLE
Update and remove subgraph schemas

### DIFF
--- a/__wundergraph__/subgraphs/mood/schema.graphql
+++ b/__wundergraph__/subgraphs/mood/schema.graphql
@@ -1,0 +1,18 @@
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@authenticated", "@composeDirective", "@external", "@extends", "@inaccessible", "@interfaceObject", "@override", "@provides", "@key", "@requires", "@requiresScopes", "@shareable", "@tag"])
+
+type Mutation {
+  """ This mutation update the mood of an employee. """
+  updateMood(employeeID: Int!, mood: Mood!): Employee!
+}
+
+enum Mood {
+  APATHETIC @inaccessible
+  HAPPY
+  SAD
+}
+
+type Employee @key(fields: "id") {
+  id: Int!
+  currentMood: Mood!
+  b: String
+}


### PR DESCRIPTION
This PR makes the following changes to GraphQL schemas:

Updates:
- mood

Created by WunderGraph Hub.